### PR TITLE
Fix issue when using with async pipe

### DIFF
--- a/src/ng2-filter.pipe.ts
+++ b/src/ng2-filter.pipe.ts
@@ -13,6 +13,7 @@ export class Ng2SearchPipe implements PipeTransform {
    */
   transform(items: any, term: any): any {
     if (term === undefined) return items;
+    if (!items) return items;
 
     return items.filter(function(item) {
       for(let property in item){


### PR DESCRIPTION
When using with an async pipe, the first time the filter is called
the items is null, this filter will fail in this case.