### PR TITLE
Set type of filter parameter to "any"

### DIFF
--- a/src/ng2-filter.pipe.ts
+++ b/src/ng2-filter.pipe.ts
@@ -14,7 +14,7 @@ export class Ng2SearchPipe implements PipeTransform {
   transform(items: any, term: any): any {
     if (term === undefined) return items;
 
-    return items.filter(function(item) {
+    return items.filter(function(item: any) {
       for(let property in item){
         if (item[property] === null){
           continue;


### PR DESCRIPTION
This fix #24 

see: https://stackoverflow.com/questions/43064221/typescript-ts7006-parameter-xxx-implicitly-has-an-any-type